### PR TITLE
resource table: add helper to add resource table in project.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,3 +14,7 @@ set(LIBMETAL_LIB ${ZEPHYR_BINARY_DIR}/ext/hal/libmetal/lib)
 
 add_subdirectory(${CONFIG_OPENAMP_SRC_PATH} open-amp)
 endif()
+
+if(CONFIG_RSC_TABLE)
+add_subdirectory(${CONFIG_RSC_TABLE_SRC_PATH} rsc_table)
+endif()

--- a/README
+++ b/README
@@ -9,6 +9,8 @@ Status:
 
    When we import open-amp we removed the apps dir to reduce the amount of
    code imported.
+   We also add resource table source code that can be used to declare a resource
+   table in project.
 Purpose:
    IPC layer that implements rpmsg communication between cores.
 

--- a/rsc_table/CMakeLists.txt
+++ b/rsc_table/CMakeLists.txt
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2019 STMicroelectronics
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+zephyr_include_directories_ifdef(CONFIG_RSC_TABLE .)
+zephyr_sources_ifdef(CONFIG_RSC_TABLE resource_table.c)
+

--- a/rsc_table/README
+++ b/rsc_table/README
@@ -1,0 +1,21 @@
+
+Description:
+
+In addition to the standard ELF segments, most remote processors would
+also include a special section which we call "the resource table".
+
+The resource table contains system resources that the remote processor
+requires before it should be powered on, such as allocation of physically
+contiguous memory, or iommu mapping of certain on-chip peripherals.
+
+In addition to system resources, the resource table may also contain
+resource entries that publish the existence of supported features
+or configurations by the remote processor, such as trace buffers and
+supported virtio devices (and their configurations).
+
+Dependencies:
+  to be compliant with Linux kernel OS the resource table must be linked in a
+  specific section named ".resource_table".
+
+Related documentation:
+  https://www.kernel.org/doc/Documentation/remoteproc.txt

--- a/rsc_table/resource_table.c
+++ b/rsc_table/resource_table.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2019 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <resource_table.h>
+
+extern char ram_console[];
+
+#define __section_t(S)          __attribute__((__section__(#S)))
+#define __resource              __section_t(.resource_table)
+
+#if (CONFIG_RSC_TABLE_NUM_RPMSG_BUFF > 0) || defined(CONFIG_RAM_CONSOLE)
+
+static struct fw_resource_table __resource resource_table = {
+	.ver = 1,
+	.num = RSC_TABLE_NUM_ENTRY,
+	.offset = {
+#if (CONFIG_RSC_TABLE_NUM_RPMSG_BUFF > 0)
+		offsetof(struct fw_resource_table, vdev),
+#endif
+#if defined(CONFIG_RAM_CONSOLE)
+		offsetof(struct fw_resource_table, cm_trace),
+#endif
+	},
+
+#if (CONFIG_RSC_TABLE_NUM_RPMSG_BUFF > 0)
+	/* Virtio device entry */
+	.vdev = {
+		RSC_VDEV, VIRTIO_ID_RPMSG, 0, RPMSG_IPU_C0_FEATURES, 0, 0, 0,
+		VRING_COUNT, {0, 0},
+	},
+
+	/* Vring rsc entry - part of vdev rsc entry */
+	.vring0 = {VRING_TX_ADDRESS, VRING_ALIGNMENT,
+		   CONFIG_RSC_TABLE_NUM_RPMSG_BUFF,
+		   VRING0_ID, 0},
+	.vring1 = {VRING_RX_ADDRESS, VRING_ALIGNMENT,
+		   CONFIG_RSC_TABLE_NUM_RPMSG_BUFF,
+		   VRING1_ID, 0},
+#endif
+
+#if defined(CONFIG_RAM_CONSOLE)
+	.cm_trace = {
+		RSC_TRACE,
+		(uint32_t)ram_console, CONFIG_RAM_CONSOLE_BUFFER_SIZE + 1, 0,
+		"Zephyr_log",
+	},
+#endif
+};
+
+void rsc_table_get(void **table_ptr, int *length)
+{
+	*table_ptr = (void *)&resource_table;
+	*length = sizeof(resource_table);
+}
+#endif

--- a/rsc_table/resource_table.h
+++ b/rsc_table/resource_table.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2019 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef RESOURCE_TABLE_H__
+#define RESOURCE_TABLE_H__
+
+#include <openamp/remoteproc.h>
+#include <openamp/virtio.h>
+
+#if (CONFIG_RSC_TABLE_NUM_RPMSG_BUFF > 0)
+
+#define VDEV_ID                 0xFF
+#define VRING0_ID 0 /* (master to remote) fixed to 0 for Linux compatibility */
+#define VRING1_ID 1 /* (remote to master) fixed to 1 for Linux compatibility */
+
+#define VRING_COUNT             2
+#define RPMSG_IPU_C0_FEATURES   1
+
+#define VRING_RX_ADDRESS        -1  /* allocated by Master processor */
+#define VRING_TX_ADDRESS        -1  /* allocated by Master processor */
+#define VRING_BUFF_ADDRESS      -1  /* allocated by Master processor */
+#define VRING_ALIGNMENT         16  /* fixed to match with Linux constraint */
+
+#endif
+
+enum rsc_table_entries {
+#if (CONFIG_RSC_TABLE_NUM_RPMSG_BUFF > 0)
+	RSC_TABLE_VDEV_ENTRY,
+#endif
+#if defined(CONFIG_RAM_CONSOLE)
+	RSC_TABLE_TRACE_ENTRY,
+#endif
+	RSC_TABLE_NUM_ENTRY
+};
+
+struct fw_resource_table {
+	unsigned int ver;
+	unsigned int num;
+	unsigned int reserved[2];
+	unsigned int offset[RSC_TABLE_NUM_ENTRY];
+
+	struct fw_rsc_vdev vdev;
+	struct fw_rsc_vdev_vring vring0;
+	struct fw_rsc_vdev_vring vring1;
+
+#if defined(CONFIG_RAM_CONSOLE)
+	/* rpmsg trace entry */
+	struct fw_rsc_trace cm_trace;
+#endif
+} OPENAMP_PACKED_END;
+
+void rsc_table_get(void **table_ptr, int *length);
+
+inline struct fw_rsc_vdev *rsc_table_to_vdev(void *rsc_table)
+{
+	return &((struct fw_resource_table *)rsc_table)->vdev;
+}
+
+inline struct fw_rsc_vdev_vring *rsc_table_get_vring0(void *rsc_table)
+{
+	return &((struct fw_resource_table *)rsc_table)->vring0;
+}
+
+inline struct fw_rsc_vdev_vring *rsc_table_get_vring1(void *rsc_table)
+{
+	return &((struct fw_resource_table *)rsc_table)->vring1;
+}
+
+#endif


### PR DESCRIPTION
The resource table is needed by the Linux kernel OS
for rpmsg generic support, but is also recognised by OpenAMP.
This table  allows to add trace based on the RAM console
and to support rpmsg protocol.

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@st.com>