### PR TITLE
remoteproc: fix compilation warning in elf loader

### DIFF
--- a/open-amp/lib/remoteproc/elf_loader.c
+++ b/open-amp/lib/remoteproc/elf_loader.c
@@ -360,7 +360,7 @@ static const void *elf_next_load_segment(void *elf_info, int *nseg,
 				   size_t *noffset, size_t *nfsize,
 				   size_t *nmsize)
 {
-	const void *phdr;
+	const void *phdr = PT_NULL;
 	unsigned int p_type = PT_NULL;
 
 	if (elf_info == NULL || nseg == NULL)


### PR DESCRIPTION
Fix uninitialised compilation warning that generates CI error report.
This patch have also been proposed to OpenAMP
(https://github.com/OpenAMP/open-amp/pull/173)

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@st.com>