### PR TITLE
Back-port from OpenAMP project

### DIFF
--- a/open-amp/cmake/options.cmake
+++ b/open-amp/cmake/options.cmake
@@ -3,9 +3,9 @@ set (PROJECT_VER_MINOR  1)
 set (PROJECT_VER_PATCH  0)
 set (PROJECT_VER        0.1.0)
 
-if (NOT CMAKE_BUILD_TYPE)
+if (NOT DEFINED CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE Debug)
-endif (NOT CMAKE_BUILD_TYPE)
+endif (NOT DEFINED CMAKE_BUILD_TYPE)
 
 if (NOT CMAKE_INSTALL_LIBDIR)
   set (CMAKE_INSTALL_LIBDIR "lib")
@@ -73,6 +73,10 @@ if (WITH_ZEPHYR)
 endif (WITH_ZEPHYR)
 
 option (WITH_LIBMETAL_FIND "Check Libmetal library can be found" ON)
+
+if (DEFINED RPMSG_BUFFER_SIZE)
+  add_definitions( -DRPMSG_BUFFER_SIZE=${RPMSG_BUFFER_SIZE} )
+endif (DEFINED RPMSG_BUFFER_SIZE)
 
 message ("-- C_FLAGS : ${CMAKE_C_FLAGS}")
 # vim: expandtab:ts=2:sw=2:smartindent

--- a/open-amp/lib/CMakeLists.txt
+++ b/open-amp/lib/CMakeLists.txt
@@ -34,8 +34,8 @@ set_property (SOURCE ${_sources}
 # Build a shared library if so configured.
 if (WITH_ZEPHYR)
   zephyr_library_named(${OPENAMP_LIB})
-  add_dependencies(${OPENAMP_LIB} offsets_h)
-  target_sources (${OPENAMP_LIB} PRIVATE ${_sources})
+  add_dependencies(${ZEPHYR_CURRENT_LIBRARY} ${OFFSETS_H_TARGET})
+  zephyr_library_sources(${_sources})
   zephyr_include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 else (WITH_ZEPHYR)
   if (WITH_SHARED_LIB)

--- a/open-amp/lib/include/openamp/virtio_ring.h
+++ b/open-amp/lib/include/openamp/virtio_ring.h
@@ -9,6 +9,8 @@
 #ifndef VIRTIO_RING_H
 #define	VIRTIO_RING_H
 
+#include <metal/compiler.h>
+
 #if defined __cplusplus
 extern "C" {
 #endif
@@ -34,6 +36,7 @@ extern "C" {
 /* VirtIO ring descriptors: 16 bytes.
  * These can chain together via "next".
  */
+METAL_PACKED_BEGIN
 struct vring_desc {
 	/* Address (guest-physical). */
 	uint64_t addr;
@@ -43,15 +46,17 @@ struct vring_desc {
 	uint16_t flags;
 	/* We chain unused descriptors via this, too. */
 	uint16_t next;
-};
+}METAL_PACKED_END;
 
+METAL_PACKED_BEGIN
 struct vring_avail {
 	uint16_t flags;
 	uint16_t idx;
 	uint16_t ring[0];
-};
+}METAL_PACKED_END;
 
 /* uint32_t is used here for ids for padding reasons. */
+METAL_PACKED_BEGIN
 struct vring_used_elem {
 	union {
 		uint16_t event;
@@ -60,13 +65,14 @@ struct vring_used_elem {
 	};
 	/* Total length of the descriptor chain which was written to. */
 	uint32_t len;
-};
+}METAL_PACKED_END;
 
+METAL_PACKED_BEGIN
 struct vring_used {
 	uint16_t flags;
 	uint16_t idx;
 	struct vring_used_elem ring[0];
-};
+}METAL_PACKED_END;
 
 struct vring {
 	unsigned int num;

--- a/open-amp/lib/rpmsg/rpmsg_virtio.c
+++ b/open-amp/lib/rpmsg/rpmsg_virtio.c
@@ -308,7 +308,7 @@ static int rpmsg_virtio_send_offchannel_raw(struct rpmsg_device *rdev,
 		/* Lock the device to enable exclusive access to virtqueues */
 		metal_mutex_acquire(&rdev->lock);
 		avail_size = _rpmsg_virtio_get_buffer_size(rvdev);
-		if (size > avail_size) {
+		if (avail_size && size > avail_size) {
 			metal_mutex_release(&rdev->lock);
 			return RPMSG_ERR_BUFF_SIZE;
 		}


### PR DESCRIPTION
backport of 2 patches pushed on https://github.com/OpenAMP/open-amp to fix compilation issues on zephyr project.

https://github.com/OpenAMP/open-amp/pull/198
https://github.com/OpenAMP/open-amp/pull/199