### PR TITLE
cmake: set the policy CMP0077 to NEW

### DIFF
--- a/open-amp/CMakeLists.txt
+++ b/open-amp/CMakeLists.txt
@@ -3,6 +3,10 @@ if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif()
 
+if (POLICY CMP0077)
+  cmake_policy(SET CMP0077 NEW)
+endif()
+
 # The version number
 set (OPENAMP_VERSION_MAJOR 1)
 set (OPENAMP_VERSION_MINOR 0)


### PR DESCRIPTION
Fixes: #zephyr/issues/26142

This commit introduces CMP0077 and set the policy to NEW behavior.

Both OLD and NEW behavior will use the value defined earlier in the
CMake process, however the OLD behavior will also add an entry to the
CMakeCache.txt but ignore that value on sub-sequent invocations.
As this may lead to confusion on users looking into the CMakeCache.txt,
then the best is to not get such values into the cache, and thus use NEW
behavior.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>